### PR TITLE
revoke hiding of changeNote field from Volto in VLT

### DIFF
--- a/frontend/packages/volto-tagung-plone-de/src/theme/_main.scss
+++ b/frontend/packages/volto-tagung-plone-de/src/theme/_main.scss
@@ -1,2 +1,9 @@
 @import 'variables';
 @import 'components/footer';
+
+
+// revoke hiding changeNote field from edit & add forms 
+.field-wrapper-changeNote {
+    display: block;
+  }
+

--- a/frontend/packages/volto-tagung-plone-de/src/theme/_main.scss
+++ b/frontend/packages/volto-tagung-plone-de/src/theme/_main.scss
@@ -1,9 +1,7 @@
 @import 'variables';
 @import 'components/footer';
 
-
-// revoke hiding changeNote field from edit & add forms 
+// revoke hiding changeNote field from edit & add forms
 .field-wrapper-changeNote {
-    display: block;
-  }
-
+  display: block;
+}


### PR DESCRIPTION
In VLT the changeNote field is hidden without no good reason. 
See: https://github.com/kitconcept/volto-light-theme/issues/488

For my work as editor using changelogs is crucial. This exposes the field again with all the existing, but minor, UX flaws remaining at the current place in VoltoUI.